### PR TITLE
Reorganise args and allow dirname pass in to new.

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -18,14 +18,15 @@ func (createLayout *CreateLayoutRuntime) newCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "new",
 		Short: "Create a new directory and config file layout for a jinkies!",
-		Long: `There are a lot of moving parts to getting Jenkins configured programatically, including init.groovy.d files,
-a Dockerfile, build script stuff, the whole nine yards.
+		Args:  cobra.ExactArgs(1),
+		Long: `Run 'jinx new <dir>' to set up the skeleton of a new jinx project in a new starting dir! Use 'jinx new .' 
+to use the current dir.
 
-Instead of forcing you to do just download my upstream container, I figured a project generator would put more control
-back in your hands.
+There are a lot of moving parts to getting Jenkins configured programatically, including init.groovy.d files,
+a Dockerfile, build script stuff, the whole nine yards.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := jinkiesengine.CreateLayout(".", createLayout.GlobalRuntime)
+			err := jinkiesengine.CreateLayout(createLayout.GlobalRuntime, args[0])
 			return err
 		},
 	}

--- a/src/jinkiesengine/create_layout.go
+++ b/src/jinkiesengine/create_layout.go
@@ -11,7 +11,14 @@ import (
 //go:embed embed_files/version.txt
 var version []byte
 
-func CreateLayout(topLevelDir string, globalRuntime jinxtypes.JinxGlobalRuntime) error {
+// CreateLayout first verifies if the directory exists. If it does, it returns os.ErrExist.
+func CreateLayout(globalRuntime jinxtypes.JinxGlobalRuntime, topLevelDir string) error {
+	if _, err := os.Stat(topLevelDir); os.IsNotExist(err) {
+
+		// Directory exists
+		log.Println(topLevelDir + "already exists. Putting files in...")
+	}
+
 	_, err := createFiles(topLevelDir, globalRuntime)
 
 	return err
@@ -123,12 +130,14 @@ ADD ./jinkies_support_files/ ${JENKINS_HOME}/jinkies_support_files
 
 	if err != nil {
 		log.Fatal(err)
+		return dir, err
 	}
 
 	err = os.WriteFile(dir+"/"+filename, []byte(dockerfile), 0700)
 
 	if err != nil {
 		log.Fatal(err)
+		// return's on the next line
 	}
 
 	return dir + "/" + filename, err

--- a/src/jinkiesengine/create_layout_test.go
+++ b/src/jinkiesengine/create_layout_test.go
@@ -17,7 +17,7 @@ func TestCreateLayout(t *testing.T) {
 	testDir, _ := os.MkdirTemp("", "")
 	os.Chdir(testDir)
 	defer os.RemoveAll(testDir)
-	err := CreateLayout(testDir, globalRuntime)
+	err := CreateLayout(globalRuntime, testDir)
 
 	assert.Nil(t, err)
 


### PR DESCRIPTION
I put globalruntime first because the globalruntime is always an arg to every subcommand; it makes sense that I organise the code so it's easy to find.

I wanted the dirname specifically as a feature.

[] Have you updated any appropriate docs
[] Are comments up to date
[] Did you run `go fmt`
